### PR TITLE
docs: typo fix in Readme.md

### DIFF
--- a/00-testssl-stuff/Readme.md
+++ b/00-testssl-stuff/Readme.md
@@ -7,7 +7,7 @@ Compilation instructions
 
 If you want to compile OpenSSL yourself, here are the instructions:
 
-1.) ```git clone -depth 1 https://github.com/testssl/openssl-1.0.2.bad &&
+1.) ```git clone --depth 1 https://github.com/testssl/openssl-1.0.2.bad &&
     cd openssl-1.0.2-bad```
 
 2.) Now, there are two options to compile this. Recommended is the first one below.

--- a/00-testssl-stuff/Readme.md
+++ b/00-testssl-stuff/Readme.md
@@ -8,7 +8,7 @@ Compilation instructions
 If you want to compile OpenSSL yourself, here are the instructions:
 
 1.) ```git clone --depth 1 https://github.com/testssl/openssl-1.0.2.bad &&
-    cd openssl-1.0.2-bad```
+    cd openssl-1.0.2.bad```
 
 2.) Now, there are two options to compile this. Recommended is the first one below.
 


### PR DESCRIPTION
```
git clone -depth 1 https://github.com/testssl/openssl-1.0.2.bad && cd openssl-1.0.2-bad
error: did you mean `--depth` (with two dashes)?

bash: cd: openssl-1.0.2-bad: No such file or directory
```