### PR TITLE
Fix compile error under FreeBSD ...

### DIFF
--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -35,7 +35,7 @@
 #if (defined(__unix__) || defined(unix)) && !defined(USG) && \
         (defined(OpenBSD) || defined(__FreeBSD__))
 # include <sys/param.h>
-# if (OpenBSD >= 200112) || ((__FreeBSD_version >= 470101 && __FreeBSD_version < 500000) || __FreeBSD_version >= 500041)
+# if (OpenBSD >= 200112) || ((__FreeBSD_version >= 470101 && __FreeBSD_version < 500000) || (__FreeBSD_version >= 500041 && __FreeBSD_version < 1300000))
 #  define HAVE_CRYPTODEV
 # endif
 # if (OpenBSD >= 200110)


### PR DESCRIPTION
... use of undeclared identifier 'CRIOGET'

See https://cgit.freebsd.org/ports/commit/?id=11b77b717cb1765a3eae5730d81823e0597d985a